### PR TITLE
Issue #6: Improve protection with more variants in keys

### DIFF
--- a/antibot.admin.inc
+++ b/antibot.admin.inc
@@ -28,6 +28,13 @@ function antibot_admin_settings($form, &$form_state) {
     '#default_value' => $config->get('show_form_ids'),
     '#description' => t('When enabled, the form IDs of all forms on every page will be displayed to any user with permission to access these settings. Also displayed will be whether or not Antibot is enabled for each form. This should only be turned on temporarily in order to easily determine the form IDs to use.'),
   );
+  $form['salt'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Key hash salt'),
+    '#default_value' => $config->get('salt'),
+    '#description' => t('Additional component for hidden keys to make them individual per site. If Antibot protection declines, change this string.'),
+    '#required' => TRUE,
+  );
 
   return system_settings_form($form);
 }

--- a/antibot.install
+++ b/antibot.install
@@ -5,6 +5,17 @@
  */
 
 /**
+ * Implements hook_install().
+ *
+ * Populate the "salt" setting with a random string.
+ */
+function antibot_install() {
+  $config = config('antibot.settings');
+  $config->set('salt', backdrop_random_key());
+  $config->save();
+}
+
+/**
  * Implements hook_update_N(). Switch from varaibles to config.
  */
 function antibot_update_1000() {
@@ -16,4 +27,15 @@ function antibot_update_1000() {
   // Delete the legacy variables.
   update_variable_del('antibot_form_ids');
   update_variable_del('antibot_show_form_ids');
+}
+
+/**
+ * Add hash salt string to settings.
+ */
+function antibot_update_1001() {
+  $config = config('antibot.settings');
+  if (empty($config->get('salt'))) {
+    $config->set('salt', backdrop_random_key());
+    $config->save();
+  }
 }

--- a/antibot.module
+++ b/antibot.module
@@ -97,10 +97,11 @@ function antibot_protect_form(array &$form) {
   // Ensure the form has an ID set.
   if (!empty($form['#form_id'])) {
     // Generate a key for this form.
-    $key = md5($form['#form_id']);
+    $key = _antibot_generate_key($form['#form_id']);
+    $shuffled_key = strrev(implode('', array_map('implode', array_map('array_reverse', array_chunk(str_split($key), 2)))));
 
     // Store the key in the form.
-    $form['#antibot_key'] = $key;
+    $form['#antibot_key'] = $shuffled_key;
 
     // Add a hidden value which will receive the key via JS.
     // The point of this is to add an additonal layer of protection for remotely
@@ -209,10 +210,20 @@ function antibot_form_validation($form, &$form_state) {
       return;
     }
 
+    // Get the expected key.
+    $expected_key = _antibot_generate_key($form['#form_id']);
+
     // Validate the key.
-    if (empty($form_state['input']['antibot_key']) || ($form['#antibot_key'] != $form_state['input']['antibot_key'])) {
+    if (empty($form_state['input']['antibot_key']) || ($expected_key != $form_state['input']['antibot_key'])) {
       // Prevent the form from submitting.
       form_set_error('', t('Submission failed. Please reload the page and try again.'));
     }
   }
+}
+
+/**
+ * Helper function to generate a key for a given form.
+ */
+function _antibot_generate_key($form_id) {
+  return md5($form_id . config_get('antibot.settings', 'salt'));
 }

--- a/antibot.module
+++ b/antibot.module
@@ -112,8 +112,8 @@ function antibot_protect_form(array &$form) {
       '#value' => '',
     );
 
-    // Add validation for the key at the beginning of validation.
-    array_unshift($form['#validate'], 'antibot_form_validation');
+    // Add validation for the key.
+    $form['#validate'][] = 'antibot_form_validation';
   }
 
   // Add a pre-render to activate antibot.

--- a/antibot.module
+++ b/antibot.module
@@ -112,8 +112,8 @@ function antibot_protect_form(array &$form) {
       '#value' => '',
     );
 
-    // Add validation for the key.
-    $form['#validate'][] = 'antibot_form_validation';
+    // Add validation for the key at the beginning of validation.
+    array_unshift($form['#validate'], 'antibot_form_validation');
   }
 
   // Add a pre-render to activate antibot.

--- a/config/antibot.settings.json
+++ b/config/antibot.settings.json
@@ -2,5 +2,5 @@
     "_config_name": "antibot.settings",
     "form_ids": "user_login\r\nuser_login_block\r\nuser_pass\r\nuser_register_form\r\ncomment_node_*\r\ncontact_site_form\r\nwebform_client_form_*",
     "show_form_ids": 0,
-    "antibot_key": ""
+    "salt": ""
 }

--- a/js/antibot.js
+++ b/js/antibot.js
@@ -12,19 +12,19 @@
       Backdrop.settings.antibot.human = false;
 
       // Wait for a mouse to move, indicating they are human.
-      $('body').mousemove(function() {
+      $('body').on('mousemove', function() {
         // Unlock the forms.
         Backdrop.antibot.unlockForms();
       });
 
       // Wait for a touch move event, indicating that they are human.
-      $('body').bind('touchmove', function() {
+      $('body').on('touchmove', function() {
         // Unlock the forms.
         Backdrop.antibot.unlockForms();
       });
 
       // A tab or enter key pressed can also indicate they are human.
-      $('body').keydown(function(e) {
+      $('body').on('keydown', function(e) {
         if ((e.keyCode == 9) || (e.keyCode == 13)) {
           // Unlock the forms.
           Backdrop.antibot.unlockForms();
@@ -41,14 +41,14 @@
     // Act only if we haven't yet verified this user as being human.
     if (!Backdrop.settings.antibot.human) {
       // Iterate all antibot forms that we need to unlock.
-      for (var id in Backdrop.settings.antibot.forms) {
+      for (const id in Backdrop.settings.antibot.forms) {
         // Switch the action to the original value.
         $('form#' + id).attr('action', Backdrop.settings.antibot.forms[id].action);
 
         // Check if a key is required.
         if (Backdrop.settings.antibot.forms[id].key) {
           // Inject the key value.
-          $('form#' + id).find('input[name="antibot_key"]').val(Backdrop.settings.antibot.forms[id].key);
+          $('form#' + id).find('input[name="antibot_key"]').val(Backdrop.settings.antibot.forms[id].key.split("").reverse().join("").match(/.{1,2}/g).map((value) => value.split("").reverse().join("")).join(""));
         }
       }
       // Mark this user as being human.


### PR DESCRIPTION
Fixes #6 

Based on [Drupal commit](https://git.drupalcode.org/project/antibot/-/commit/53d46364e8000423c665ece44b24b1146e4b9a94) (by tcorneli), but expanded quite a bit:

- Add a new "salt" setting to make keys individual per site, AND give site admins an option to change that key base
- Fix jQuery compatibility with newer versions
- Remove unused config key from default config
